### PR TITLE
Allow existing selected values

### DIFF
--- a/lib/select-popover.js
+++ b/lib/select-popover.js
@@ -7,6 +7,7 @@ var HiddenSelectField   = require("./hidden-select-field"),
 var SelectPopover = React.createClass({displayName: "SelectPopover",
   propTypes: {
     options             : React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+    selectedOptions     : React.PropTypes.arrayOf(React.PropTypes.object),
     name                : React.PropTypes.string,
     selectPlaceholder   : React.PropTypes.string,
     componentClassNames : React.PropTypes.arrayOf(React.PropTypes.string),
@@ -29,7 +30,7 @@ var SelectPopover = React.createClass({displayName: "SelectPopover",
   getInitialState: function() {
     return {
       searchTerm        : "",
-      selectedValues    : [],
+      selectedValues    : this.props.selectedOptions || [],
       focus             : "out"
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-select-popover",
-  "version": "0.1.1",
+  "version": "0.1.1.1",
   "description": "A react component to convert a select box into a nifty popover with prepopulated options",
   "main": "lib/select-popover.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-select-popover",
-  "version": "0.1.1.1",
+  "version": "0.1.2",
   "description": "A react component to convert a select box into a nifty popover with prepopulated options",
   "main": "lib/select-popover.js",
   "scripts": {

--- a/src/scripts/components/select-popover.jsx
+++ b/src/scripts/components/select-popover.jsx
@@ -7,6 +7,7 @@ var HiddenSelectField   = require("./hidden-select-field"),
 var SelectPopover = React.createClass({
   propTypes: {
     options             : React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+    selectedOptions     : React.PropTypes.arrayOf(React.PropTypes.object),
     name                : React.PropTypes.string,
     selectPlaceholder   : React.PropTypes.string,
     componentClassNames : React.PropTypes.arrayOf(React.PropTypes.string),
@@ -29,7 +30,7 @@ var SelectPopover = React.createClass({
   getInitialState: function() {
     return {
       searchTerm        : "",
-      selectedValues    : [],
+      selectedValues    : this.props.selectedOptions || [],
       focus             : "out"
     }
   },


### PR DESCRIPTION
In some cases the component may need to be populated with existing values. if we send in an array of label/value pairs to props.selectedOptions and initialize the state from that, we can easily support this.
